### PR TITLE
Show 1 min instead of 60 secs

### DIFF
--- a/timer-days.html
+++ b/timer-days.html
@@ -287,7 +287,7 @@ Custom property | Description | Default
           var noHours = noDays % 3600000;
           this._mins = Math.floor(noHours / 60000);
           var noMins = noHours % 60000;
-          this._secs = Math.floor(noMins / 1000) + 1;
+          this._secs = Math.floor(noMins / 1000);
         } else {
           this._days = 0;
           this._hours = 0;


### PR DESCRIPTION
For minutes show 59 and for seconds 60, that normalize the behavior of the timer and always show the max minus one (23 hours, 59 minutes and 59 seconds).
